### PR TITLE
fix(security): harden Strava attestations

### DIFF
--- a/packages/contracts/src/StravaPortal.sol
+++ b/packages/contracts/src/StravaPortal.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { AbstractPortalV2 } from "@verax-attestation-registry/verax-contracts/contracts/abstracts/AbstractPortalV2.sol";
 import { AttestationPayload } from "@verax-attestation-registry/verax-contracts/contracts/types/Structs.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -12,10 +11,11 @@ import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
  * @author alain.linea.eth
  * @notice This contract creates attestations for completed Strava segments
  */
-contract StravaPortal is AbstractPortalV2, Ownable, EIP712 {
+contract StravaPortal is AbstractPortalV2, EIP712 {
     uint256 public fee = 0.0001 ether;
     address public signerAddress;
     bytes32 public schemaId;
+    mapping(bytes32 => bool) public usedAttestations;
     string private constant SIGNING_DOMAIN = "VerifyStrava";
     string private constant SIGNATURE_VERSION = "1";
 
@@ -24,6 +24,8 @@ contract StravaPortal is AbstractPortalV2, Ownable, EIP712 {
     error SenderIsNotSubject();
     error InsufficientFee();
     error InvalidSignature();
+    error SignatureExpired();
+    error SignatureAlreadyUsed();
     error NotImplemented();
 
     struct SegmentPayload {
@@ -57,7 +59,7 @@ contract StravaPortal is AbstractPortalV2, Ownable, EIP712 {
         AttestationPayload memory attestationPayload,
         bytes[] memory validationPayloads,
         uint256 value
-    ) internal view override {
+    ) internal override {
         if (attestationPayload.subject.length != 20) revert InvalidSubject();
         address subject = address(uint160(bytes20(attestationPayload.subject)));
         if (msg.sender != subject) revert SenderIsNotSubject();
@@ -66,7 +68,16 @@ contract StravaPortal is AbstractPortalV2, Ownable, EIP712 {
         if (attestationPayload.schemaId != schemaId) revert InvalidSchema();
 
         SegmentPayload memory payload = abi.decode(attestationPayload.attestationData, (SegmentPayload));
-        if (!verifySignature(validationPayloads[0], payload.segmentId, subject)) revert InvalidSignature();
+        if (validationPayloads.length == 0) revert InvalidSignature();
+        (bytes memory signature, uint64 deadline) = abi.decode(validationPayloads[0], (bytes, uint64));
+        if (block.timestamp > deadline) revert SignatureExpired();
+
+        bytes32 attestationDigest = hashAttestation(payload.segmentId, payload.completionDate, subject);
+        if (usedAttestations[attestationDigest]) revert SignatureAlreadyUsed();
+        if (!verifySignature(signature, payload.segmentId, payload.completionDate, subject, deadline)) {
+            revert InvalidSignature();
+        }
+        usedAttestations[attestationDigest] = true;
     }
 
     /**
@@ -123,7 +134,7 @@ contract StravaPortal is AbstractPortalV2, Ownable, EIP712 {
      * @notice Set the fee required to attest
      * @param attestationFee The fee required to attest
      */
-    function setFee(uint256 attestationFee) public onlyOwner {
+    function setFee(uint256 attestationFee) public onlyPortalOwner {
         emit FeeUpdated(fee, attestationFee);
         fee = attestationFee;
     }
@@ -132,7 +143,7 @@ contract StravaPortal is AbstractPortalV2, Ownable, EIP712 {
      * @notice Set the signer address for signature verification
      * @param _signerAddress The new signer address
      */
-    function setSignerAddress(address _signerAddress) public onlyOwner {
+    function setSignerAddress(address _signerAddress) public onlyPortalOwner {
         emit SignerAddressUpdated(signerAddress, _signerAddress);
         signerAddress = _signerAddress;
     }
@@ -141,7 +152,7 @@ contract StravaPortal is AbstractPortalV2, Ownable, EIP712 {
      * @notice Set the schema ID for attestations
      * @param _schemaId The new schema ID
      */
-    function setSchemaId(bytes32 _schemaId) public onlyOwner {
+    function setSchemaId(bytes32 _schemaId) public onlyPortalOwner {
         emit SchemaIdUpdated(schemaId, _schemaId);
         schemaId = _schemaId;
     }
@@ -150,22 +161,56 @@ contract StravaPortal is AbstractPortalV2, Ownable, EIP712 {
      * @notice Verify the signature of a segment attestation
      * @param signature The signature to verify
      * @param segmentId The Strava segment ID
+     * @param completionDate The timestamp of the segment effort
      * @param subject The address of the attester
      * @return True if the signature is valid
      */
-    function verifySignature(bytes memory signature, uint256 segmentId, address subject) internal view returns (bool) {
-        bytes32 digest = _hashTypedDataV4(
-            keccak256(abi.encode(keccak256("Segment(uint256 segmentId,address subject)"), segmentId, subject))
-        );
+    function verifySignature(
+        bytes memory signature,
+        uint256 segmentId,
+        uint64 completionDate,
+        address subject,
+        uint64 deadline
+    ) internal view returns (bool) {
+        bytes32 digest = hashSegment(segmentId, completionDate, subject, deadline);
         address signer = ECDSA.recover(digest, signature);
         return signer == signerAddress;
+    }
+
+    function hashSegment(
+        uint256 segmentId,
+        uint64 completionDate,
+        address subject,
+        uint64 deadline
+    ) internal view returns (bytes32) {
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    keccak256("Segment(uint256 segmentId,uint64 completionDate,address subject,uint64 deadline)"),
+                    segmentId,
+                    completionDate,
+                    subject,
+                    deadline
+                )
+            )
+        );
+        return digest;
+    }
+
+    function hashAttestation(
+        uint256 segmentId,
+        uint64 completionDate,
+        address subject
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(segmentId, completionDate, subject));
     }
 
     /**
      * @notice Withdraw collected fees
      */
-    function withdraw() public onlyOwner {
-        (bool success, ) = owner().call{ value: address(this).balance }("");
+    function withdraw() public onlyPortalOwner {
+        address portalOwner = portalRegistry.getPortalOwner(address(this));
+        (bool success, ) = payable(portalOwner).call{ value: address(this).balance }("");
         require(success, "Transfer failed");
     }
 }

--- a/packages/contracts/src/test/StravaPortalHarness.sol
+++ b/packages/contracts/src/test/StravaPortalHarness.sol
@@ -21,8 +21,10 @@ contract StravaPortalHarness is StravaPortal {
     function exposed_verifySignature(
         bytes memory signature,
         uint256 segmentId,
-        address subject
+        uint64 completionDate,
+        address subject,
+        uint64 deadline
     ) external view returns (bool) {
-        return verifySignature(signature, segmentId, subject);
+        return verifySignature(signature, segmentId, completionDate, subject, deadline);
     }
 }

--- a/packages/contracts/test/StravaPortal.integration.test.ts
+++ b/packages/contracts/test/StravaPortal.integration.test.ts
@@ -29,6 +29,7 @@ describe('StravaPortal Integration', () => {
   const testSchemaId = '0xc1708360b3df59e91dfd33f901c659c0350461e6a30392d1e3218d4847e6b20d' as Hex;
   const testSegmentId = BigInt(12345);
   const testCompletionDate = BigInt(Math.floor(Date.now() / 1000));
+  const testDeadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
   const testFee = parseEther('0.0001');
 
   // Contract instances (initialized in beforeAll)
@@ -38,12 +39,18 @@ describe('StravaPortal Integration', () => {
   let portalHarness: Address;
   let publicClient: PublicClient<Transport, Chain>;
   let walletClient: WalletClient<Transport, Chain, Account>;
+  let userWalletClient: WalletClient<Transport, Chain, Account>;
   let owner: Address;
   let user: Address;
   let chainId: number;
 
   // Helper to sign a segment
-  async function signSegment(segmentId: bigint, subject: Address): Promise<Hex> {
+  async function signSegment(
+    segmentId: bigint,
+    completionDate: bigint,
+    subject: Address,
+    deadline: bigint = testDeadline,
+  ): Promise<Hex> {
     const domain = {
       name: 'VerifyStrava',
       version: '1',
@@ -54,13 +61,17 @@ describe('StravaPortal Integration', () => {
     const types = {
       Segment: [
         { name: 'segmentId', type: 'uint256' },
+        { name: 'completionDate', type: 'uint64' },
         { name: 'subject', type: 'address' },
+        { name: 'deadline', type: 'uint64' },
       ],
     };
 
     const message = {
       segmentId,
+      completionDate,
       subject,
+      deadline,
     };
 
     return await signerAccount.signTypedData({
@@ -71,11 +82,25 @@ describe('StravaPortal Integration', () => {
     });
   }
 
+  // Helper to encode subject as bytes20
+  function encodeSubject(address: Address): Hex {
+    const bytes = address.toLowerCase().slice(2);
+    return `0x${bytes}` as Hex;
+  }
+
   // Helper to encode attestation data
   function encodeAttestationData(segmentId: bigint, completionDate: bigint): Hex {
     return encodeAbiParameters(parseAbiParameters('uint256 segmentId, uint64 completionDate'), [
       segmentId,
       completionDate,
+    ]);
+  }
+
+  // Helper to encode validation payload
+  function encodeValidationPayload(signature: Hex, deadline: bigint = testDeadline): Hex {
+    return encodeAbiParameters(parseAbiParameters('bytes signature, uint64 deadline'), [
+      signature,
+      deadline,
     ]);
   }
 
@@ -93,13 +118,8 @@ describe('StravaPortal Integration', () => {
     owner = walletClient.account.address;
     chainId = await publicClient.getChainId();
 
-    // Get a second account for testing
-    const testWallets = await viem.getWalletClients();
-    if (testWallets && testWallets.length > 1 && testWallets[1]?.account?.address) {
-      user = testWallets[1].account.address;
-    } else {
-      user = owner;
-    }
+    userWalletClient = walletClients[1] ?? primaryWallet;
+    user = userWalletClient.account.address;
 
     // Deploy MockRouter
     const mockRouterArtifact = await hre.artifacts.readArtifact('MockRouter');
@@ -178,29 +198,31 @@ describe('StravaPortal Integration', () => {
         functionName: 'schemaId',
       });
 
-      const contractOwner = await publicClient.readContract({
-        address: portal,
-        abi: portalArtifact.abi,
-        functionName: 'owner',
+      const mockPortalRegistryArtifact = await hre.artifacts.readArtifact('MockPortalRegistry');
+      const portalOwner = await publicClient.readContract({
+        address: mockPortalRegistry,
+        abi: mockPortalRegistryArtifact.abi,
+        functionName: 'getPortalOwner',
+        args: [portal],
       });
 
       expect(fee).toBe(testFee);
       expect(getAddress(storedSignerAddress as string)).toBe(getAddress(signerAddress));
       expect(storedSchemaId).toBe(testSchemaId);
-      expect(getAddress(contractOwner as string)).toBe(getAddress(owner));
+      expect(getAddress(portalOwner as string)).toBe(getAddress(owner));
     });
   });
 
   describe('Signature Verification', () => {
     it('should verify valid signature', async () => {
       const harnessArtifact = await hre.artifacts.readArtifact('StravaPortalHarness');
-      const signature = await signSegment(testSegmentId, user);
+      const signature = await signSegment(testSegmentId, testCompletionDate, user);
 
       const isValid = await publicClient.readContract({
         address: portalHarness,
         abi: harnessArtifact.abi,
         functionName: 'exposed_verifySignature',
-        args: [signature, testSegmentId, user],
+        args: [signature, testSegmentId, testCompletionDate, user, testDeadline],
       });
 
       expect(isValid).toBe(true);
@@ -208,14 +230,28 @@ describe('StravaPortal Integration', () => {
 
     it('should reject signature with wrong segment ID', async () => {
       const harnessArtifact = await hre.artifacts.readArtifact('StravaPortalHarness');
-      const signature = await signSegment(testSegmentId, user);
+      const signature = await signSegment(testSegmentId, testCompletionDate, user);
       const wrongSegmentId = BigInt(99999);
 
       const isValid = await publicClient.readContract({
         address: portalHarness,
         abi: harnessArtifact.abi,
         functionName: 'exposed_verifySignature',
-        args: [signature, wrongSegmentId, user],
+        args: [signature, wrongSegmentId, testCompletionDate, user, testDeadline],
+      });
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject signature with wrong completion date', async () => {
+      const harnessArtifact = await hre.artifacts.readArtifact('StravaPortalHarness');
+      const signature = await signSegment(testSegmentId, testCompletionDate, user);
+
+      const isValid = await publicClient.readContract({
+        address: portalHarness,
+        abi: harnessArtifact.abi,
+        functionName: 'exposed_verifySignature',
+        args: [signature, testSegmentId, testCompletionDate + 1n, user, testDeadline],
       });
 
       expect(isValid).toBe(false);
@@ -223,14 +259,14 @@ describe('StravaPortal Integration', () => {
 
     it('should reject signature with wrong subject', async () => {
       const harnessArtifact = await hre.artifacts.readArtifact('StravaPortalHarness');
-      const signature = await signSegment(testSegmentId, user);
+      const signature = await signSegment(testSegmentId, testCompletionDate, user);
       const wrongSubject = getAddress('0x0000000000000000000000000000000000000001');
 
       const isValid = await publicClient.readContract({
         address: portalHarness,
         abi: harnessArtifact.abi,
         functionName: 'exposed_verifySignature',
-        args: [signature, testSegmentId, wrongSubject],
+        args: [signature, testSegmentId, testCompletionDate, wrongSubject, testDeadline],
       });
 
       expect(isValid).toBe(false);
@@ -251,7 +287,9 @@ describe('StravaPortal Integration', () => {
       const types = {
         Segment: [
           { name: 'segmentId', type: 'uint256' },
+          { name: 'completionDate', type: 'uint64' },
           { name: 'subject', type: 'address' },
+          { name: 'deadline', type: 'uint64' },
         ],
       };
 
@@ -259,21 +297,165 @@ describe('StravaPortal Integration', () => {
         domain,
         types,
         primaryType: 'Segment',
-        message: { segmentId: testSegmentId, subject: user },
+        message: {
+          segmentId: testSegmentId,
+          completionDate: testCompletionDate,
+          subject: user,
+          deadline: testDeadline,
+        },
       });
 
       const isValid = await publicClient.readContract({
         address: portalHarness,
         abi: harnessArtifact.abi,
         functionName: 'exposed_verifySignature',
-        args: [wrongSignature, testSegmentId, user],
+        args: [wrongSignature, testSegmentId, testCompletionDate, user, testDeadline],
       });
 
       expect(isValid).toBe(false);
     });
   });
 
+  describe('Attestation Verification', () => {
+    it('should reject an attestation when the completion date is changed after signing', async () => {
+      const harnessArtifact = await hre.artifacts.readArtifact('StravaPortalHarness');
+      const segmentId = 44444n;
+      const signature = await signSegment(segmentId, testCompletionDate, user);
+
+      await expect(
+        userWalletClient.writeContract({
+          address: portalHarness,
+          abi: harnessArtifact.abi,
+          functionName: 'attest',
+          args: [
+            {
+              schemaId: testSchemaId,
+              expirationDate: 0n,
+              subject: encodeSubject(user),
+              attestationData: encodeAttestationData(segmentId, testCompletionDate + 1n),
+            },
+            [encodeValidationPayload(signature)],
+          ],
+          value: testFee,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('should reject replayed attestations with the same signed payload', async () => {
+      const harnessArtifact = await hre.artifacts.readArtifact('StravaPortalHarness');
+      const segmentId = 55555n;
+      const signature = await signSegment(segmentId, testCompletionDate, user);
+      const attestationPayload = {
+        schemaId: testSchemaId,
+        expirationDate: 0n,
+        subject: encodeSubject(user),
+        attestationData: encodeAttestationData(segmentId, testCompletionDate),
+      };
+      const validationPayload = encodeValidationPayload(signature);
+
+      const hash = await userWalletClient.writeContract({
+        address: portalHarness,
+        abi: harnessArtifact.abi,
+        functionName: 'attest',
+        args: [attestationPayload, [validationPayload]],
+        value: testFee,
+      });
+      await publicClient.waitForTransactionReceipt({ hash });
+
+      await expect(
+        userWalletClient.writeContract({
+          address: portalHarness,
+          abi: harnessArtifact.abi,
+          functionName: 'attest',
+          args: [attestationPayload, [validationPayload]],
+          value: testFee,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('should reject attestations after the signed deadline', async () => {
+      const harnessArtifact = await hre.artifacts.readArtifact('StravaPortalHarness');
+      const segmentId = 66666n;
+      const expiredDeadline = 1n;
+      const signature = await signSegment(segmentId, testCompletionDate, user, expiredDeadline);
+
+      await expect(
+        userWalletClient.writeContract({
+          address: portalHarness,
+          abi: harnessArtifact.abi,
+          functionName: 'attest',
+          args: [
+            {
+              schemaId: testSchemaId,
+              expirationDate: 0n,
+              subject: encodeSubject(user),
+              attestationData: encodeAttestationData(segmentId, testCompletionDate),
+            },
+            [encodeValidationPayload(signature, expiredDeadline)],
+          ],
+          value: testFee,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
   describe('Admin Functions', () => {
+    it('should authorize admin calls against the current portal registry owner', async () => {
+      expect(getAddress(user)).not.toBe(getAddress(owner));
+
+      const portalArtifact = await hre.artifacts.readArtifact('StravaPortal');
+      const mockPortalRegistryArtifact = await hre.artifacts.readArtifact('MockPortalRegistry');
+      const newFee = parseEther('0.0003');
+
+      const transferHash = await walletClient.writeContract({
+        address: mockPortalRegistry,
+        abi: mockPortalRegistryArtifact.abi,
+        functionName: 'setPortal',
+        args: [portal, user],
+      });
+      await publicClient.waitForTransactionReceipt({ hash: transferHash });
+
+      await expect(
+        walletClient.writeContract({
+          address: portal,
+          abi: portalArtifact.abi,
+          functionName: 'setFee',
+          args: [newFee],
+        }),
+      ).rejects.toThrow();
+
+      const userSetFeeHash = await userWalletClient.writeContract({
+        address: portal,
+        abi: portalArtifact.abi,
+        functionName: 'setFee',
+        args: [newFee],
+      });
+      await publicClient.waitForTransactionReceipt({ hash: userSetFeeHash });
+
+      const fee = await publicClient.readContract({
+        address: portal,
+        abi: portalArtifact.abi,
+        functionName: 'fee',
+      });
+      expect(fee).toBe(newFee);
+
+      const resetOwnerHash = await walletClient.writeContract({
+        address: mockPortalRegistry,
+        abi: mockPortalRegistryArtifact.abi,
+        functionName: 'setPortal',
+        args: [portal, owner],
+      });
+      await publicClient.waitForTransactionReceipt({ hash: resetOwnerHash });
+
+      const resetFeeHash = await walletClient.writeContract({
+        address: portal,
+        abi: portalArtifact.abi,
+        functionName: 'setFee',
+        args: [testFee],
+      });
+      await publicClient.waitForTransactionReceipt({ hash: resetFeeHash });
+    });
+
     it('should allow owner to set fee', async () => {
       const portalArtifact = await hre.artifacts.readArtifact('StravaPortal');
       const newFee = parseEther('0.0002');

--- a/packages/contracts/test/StravaPortal.test.ts
+++ b/packages/contracts/test/StravaPortal.test.ts
@@ -19,12 +19,15 @@ describe('StravaPortal', () => {
   // Test data
   const testSegmentId = BigInt(12345);
   const testCompletionDate = BigInt(Math.floor(Date.now() / 1000));
+  const testDeadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
   const testFee = BigInt('100000000000000'); // 0.0001 ETH
 
   // Helper to create EIP-712 signature
   async function signSegment(
     segmentId: bigint,
+    completionDate: bigint,
     subject: Address,
+    deadline: bigint,
     chainId: number,
     verifyingContract: Address,
     privateKey: Hex,
@@ -41,13 +44,17 @@ describe('StravaPortal', () => {
     const types = {
       Segment: [
         { name: 'segmentId', type: 'uint256' },
+        { name: 'completionDate', type: 'uint64' },
         { name: 'subject', type: 'address' },
+        { name: 'deadline', type: 'uint64' },
       ],
     };
 
     const message = {
       segmentId,
+      completionDate,
       subject,
+      deadline,
     };
 
     return await account.signTypedData({
@@ -75,7 +82,10 @@ describe('StravaPortal', () => {
   describe('EIP-712 Type Hash', () => {
     it('should produce valid type hash for Segment struct', () => {
       const typeHash = keccak256(
-        encodePacked(['string'], ['Segment(uint256 segmentId,address subject)']),
+        encodePacked(
+          ['string'],
+          ['Segment(uint256 segmentId,uint64 completionDate,address subject,uint64 deadline)'],
+        ),
       );
 
       expect(typeHash).toHaveLength(66); // 0x + 64 hex chars
@@ -91,7 +101,9 @@ describe('StravaPortal', () => {
 
       const sig1 = await signSegment(
         testSegmentId,
+        testCompletionDate,
         testSubject,
+        testDeadline,
         chainId,
         verifyingContract,
         signerPrivateKey,
@@ -99,7 +111,9 @@ describe('StravaPortal', () => {
 
       const sig2 = await signSegment(
         testSegmentId,
+        testCompletionDate,
         testSubject,
+        testDeadline,
         chainId,
         verifyingContract,
         signerPrivateKey,
@@ -116,14 +130,18 @@ describe('StravaPortal', () => {
 
       const sig1 = await signSegment(
         testSegmentId,
+        testCompletionDate,
         subject1,
+        testDeadline,
         chainId,
         verifyingContract,
         signerPrivateKey,
       );
       const sig2 = await signSegment(
         testSegmentId,
+        testCompletionDate,
         subject2,
+        testDeadline,
         chainId,
         verifyingContract,
         signerPrivateKey,
@@ -139,14 +157,18 @@ describe('StravaPortal', () => {
 
       const sig1 = await signSegment(
         BigInt(111),
+        testCompletionDate,
         testSubject,
+        testDeadline,
         chainId,
         verifyingContract,
         signerPrivateKey,
       );
       const sig2 = await signSegment(
         BigInt(222),
+        testCompletionDate,
         testSubject,
+        testDeadline,
         chainId,
         verifyingContract,
         signerPrivateKey,
@@ -162,14 +184,18 @@ describe('StravaPortal', () => {
 
       const sig1 = await signSegment(
         testSegmentId,
+        testCompletionDate,
         testSubject,
+        testDeadline,
         chainId,
         verifyingContract,
         signerPrivateKey,
       );
       const sig2 = await signSegment(
         testSegmentId,
+        testCompletionDate,
         testSubject,
+        testDeadline,
         chainId,
         verifyingContract,
         randomPrivateKey,
@@ -184,15 +210,73 @@ describe('StravaPortal', () => {
 
       const sig1 = await signSegment(
         testSegmentId,
+        testCompletionDate,
         testSubject,
+        testDeadline,
         59141,
         verifyingContract,
         signerPrivateKey,
       );
       const sig2 = await signSegment(
         testSegmentId,
+        testCompletionDate,
         testSubject,
+        testDeadline,
         59144,
+        verifyingContract,
+        signerPrivateKey,
+      );
+
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('should produce different signatures for different completion dates', async () => {
+      const testSubject = getAddress('0x1234567890123456789012345678901234567890');
+      const chainId = 59141;
+      const verifyingContract = getAddress('0xc04228f66b1aa75a2a8f6887730f55b54281e9d9');
+
+      const sig1 = await signSegment(
+        testSegmentId,
+        testCompletionDate,
+        testSubject,
+        testDeadline,
+        chainId,
+        verifyingContract,
+        signerPrivateKey,
+      );
+      const sig2 = await signSegment(
+        testSegmentId,
+        testCompletionDate + 1n,
+        testSubject,
+        testDeadline,
+        chainId,
+        verifyingContract,
+        signerPrivateKey,
+      );
+
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('should produce different signatures for different deadlines', async () => {
+      const testSubject = getAddress('0x1234567890123456789012345678901234567890');
+      const chainId = 59141;
+      const verifyingContract = getAddress('0xc04228f66b1aa75a2a8f6887730f55b54281e9d9');
+
+      const sig1 = await signSegment(
+        testSegmentId,
+        testCompletionDate,
+        testSubject,
+        testDeadline,
+        chainId,
+        verifyingContract,
+        signerPrivateKey,
+      );
+      const sig2 = await signSegment(
+        testSegmentId,
+        testCompletionDate,
+        testSubject,
+        testDeadline + 1n,
+        chainId,
         verifyingContract,
         signerPrivateKey,
       );
@@ -266,13 +350,17 @@ describe('StravaPortal', () => {
       const types = {
         Segment: [
           { name: 'segmentId', type: 'uint256' },
+          { name: 'completionDate', type: 'uint64' },
           { name: 'subject', type: 'address' },
+          { name: 'deadline', type: 'uint64' },
         ],
       } as const;
 
       const message = {
         segmentId: testSegmentId,
+        completionDate: testCompletionDate,
         subject: getAddress('0x1234567890123456789012345678901234567890'),
+        deadline: testDeadline,
       };
 
       const hash = hashTypedData({
@@ -292,13 +380,17 @@ describe('StravaPortal', () => {
         types: {
           Segment: [
             { name: 'segmentId', type: 'uint256' },
+            { name: 'completionDate', type: 'uint64' },
             { name: 'subject', type: 'address' },
+            { name: 'deadline', type: 'uint64' },
           ],
         } as const,
         primaryType: 'Segment' as const,
         message: {
           segmentId: testSegmentId,
+          completionDate: testCompletionDate,
           subject: getAddress('0x1234567890123456789012345678901234567890'),
+          deadline: testDeadline,
         },
       };
 

--- a/packages/frontend/e2e/app.spec.ts
+++ b/packages/frontend/e2e/app.spec.ts
@@ -77,7 +77,7 @@ test('renders the OAuth error state instead of crashing', async ({ page }) => {
 
   await expect(page.locator('#root')).not.toBeEmpty();
   await expect(page.getByRole('heading', { name: /authentication error/i })).toBeVisible();
-  await expect(page.getByText(/no authorization code received/i)).toBeVisible();
+  await expect(page.getByText(/invalid authorization state/i)).toBeVisible();
   await expect(page.getByRole('button', { name: /back to home/i })).toBeVisible();
 
   runtime.assertClean();

--- a/packages/frontend/src/App.integration.test.tsx
+++ b/packages/frontend/src/App.integration.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
+import { STORAGE_KEYS } from './utils/constants';
 
 const openWalletMock = vi.fn();
 const writeContractMock = vi.fn();
@@ -63,6 +64,15 @@ describe('App routing integration', () => {
     renderRoute('/oauth');
 
     expect(await screen.findByRole('heading', { name: /authentication error/i })).toBeVisible();
-    expect(screen.getByText(/no authorization code received/i)).toBeVisible();
+    expect(screen.getByText(/invalid authorization state/i)).toBeVisible();
+  });
+
+  it('rejects an OAuth callback with mismatched state', async () => {
+    sessionStorage.setItem(STORAGE_KEYS.OAUTH_STATE, 'expected-state');
+
+    renderRoute('/oauth?code=test-code&state=wrong-state');
+
+    expect(await screen.findByRole('heading', { name: /authentication error/i })).toBeVisible();
+    expect(screen.getByText(/invalid authorization state/i)).toBeVisible();
   });
 });

--- a/packages/frontend/src/App.test.tsx
+++ b/packages/frontend/src/App.test.tsx
@@ -7,6 +7,7 @@ const STORAGE_KEYS = {
   REFRESH_TOKEN: 'strava_refresh_token',
   EXPIRES_AT: 'strava_expires_at',
   ATHLETE: 'strava_athlete',
+  OAUTH_STATE: 'strava_oauth_state',
 } as const;
 
 describe('Frontend Core Logic', () => {
@@ -39,6 +40,7 @@ describe('Frontend Core Logic', () => {
       expect(STORAGE_KEYS.REFRESH_TOKEN).toBe('strava_refresh_token');
       expect(STORAGE_KEYS.EXPIRES_AT).toBe('strava_expires_at');
       expect(STORAGE_KEYS.ATHLETE).toBe('strava_athlete');
+      expect(STORAGE_KEYS.OAUTH_STATE).toBe('strava_oauth_state');
     });
   });
 

--- a/packages/frontend/src/abi/StravaPortal.ts
+++ b/packages/frontend/src/abi/StravaPortal.ts
@@ -43,11 +43,4 @@ export const STRAVA_PORTAL_ABI = [
     stateMutability: 'view',
     type: 'function',
   },
-  {
-    inputs: [],
-    name: 'owner',
-    outputs: [{ name: '', type: 'address' }],
-    stateMutability: 'view',
-    type: 'function',
-  },
 ] as const;

--- a/packages/frontend/src/components/SegmentsModal/SegmentsModalImpl.tsx
+++ b/packages/frontend/src/components/SegmentsModal/SegmentsModalImpl.tsx
@@ -117,6 +117,10 @@ function SegmentsModalContent({
           parseAbiParameters('uint256 segmentId, uint64 completionDate'),
           [BigInt(signedSegment.segmentId), BigInt(signedSegment.completionDate)],
         );
+        const validationPayload = encodeAbiParameters(
+          parseAbiParameters('bytes signature, uint64 deadline'),
+          [signedSegment.signature, BigInt(signedSegment.deadline)],
+        );
         const subjectBytes: Hex = address.toLowerCase() as Hex;
 
         writeContract(
@@ -131,7 +135,7 @@ function SegmentsModalContent({
                 subject: subjectBytes,
                 attestationData,
               },
-              [signedSegment.signature],
+              [validationPayload],
             ],
             value: ATTESTATION_FEE,
           },

--- a/packages/frontend/src/components/StravaLoginButton/StravaLoginButton.tsx
+++ b/packages/frontend/src/components/StravaLoginButton/StravaLoginButton.tsx
@@ -1,17 +1,61 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './StravaLoginButton.module.css';
 import connectWithStrava from '../../assets/btn_strava.svg';
-import { STRAVA_AUTH_URL, STRAVA_CLIENT_ID, STRAVA_REDIRECT_URL } from '../../utils/constants';
+import {
+  API_URL,
+  STORAGE_KEYS,
+  STRAVA_AUTH_URL,
+  STRAVA_CLIENT_ID,
+  STRAVA_REDIRECT_URL,
+} from '../../utils/constants';
 
 export default function StravaLoginButton(): React.JSX.Element {
-  const handleLogin = (): void => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleLogin = async (): Promise<void> => {
+    if (isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
     const scope = 'read,activity:read_all';
 
-    window.location.href = `${STRAVA_AUTH_URL}?client_id=${STRAVA_CLIENT_ID}&redirect_uri=${STRAVA_REDIRECT_URL}&response_type=code&scope=${scope}`;
+    try {
+      const response = await fetch(`${API_URL}/auth`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ action: 'start' }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to start OAuth flow');
+      }
+
+      const { state } = (await response.json()) as { state?: string };
+      if (!state) {
+        throw new Error('Missing OAuth state');
+      }
+
+      sessionStorage.setItem(STORAGE_KEYS.OAUTH_STATE, state);
+
+      const params = new URLSearchParams({
+        client_id: STRAVA_CLIENT_ID,
+        redirect_uri: STRAVA_REDIRECT_URL,
+        response_type: 'code',
+        scope,
+        state,
+      });
+
+      window.location.href = `${STRAVA_AUTH_URL}?${params.toString()}`;
+    } catch (error) {
+      console.error('Failed to start Strava OAuth:', error);
+      setIsLoading(false);
+    }
   };
 
   return (
-    <button onClick={handleLogin} className={styles.button}>
+    <button onClick={handleLogin} className={styles.button} disabled={isLoading}>
       <img
         src={connectWithStrava}
         alt="Connect with Strava"

--- a/packages/frontend/src/hooks/useStravaAuth.test.tsx
+++ b/packages/frontend/src/hooks/useStravaAuth.test.tsx
@@ -13,7 +13,6 @@ const athlete = {
 
 function seedAuth(expiresAt: number): void {
   sessionStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, 'access-token');
-  sessionStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, 'refresh-token');
   sessionStorage.setItem(STORAGE_KEYS.EXPIRES_AT, expiresAt.toString());
   sessionStorage.setItem(STORAGE_KEYS.ATHLETE, JSON.stringify(athlete));
 }
@@ -40,7 +39,6 @@ describe('useStravaAuth', () => {
 
   it('drops corrupted athlete storage without breaking render', async () => {
     sessionStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, 'access-token');
-    sessionStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, 'refresh-token');
     sessionStorage.setItem(
       STORAGE_KEYS.EXPIRES_AT,
       (Math.floor(Date.now() / 1000) + 3600).toString(),
@@ -56,21 +54,8 @@ describe('useStravaAuth', () => {
     expect(sessionStorage.getItem(STORAGE_KEYS.ATHLETE)).toBeNull();
   });
 
-  it('refreshes an expired token and persists the new session', async () => {
+  it('clears an expired session instead of refreshing in the browser', async () => {
     seedAuth(Math.floor(Date.now() / 1000) - 3600);
-
-    const fetchMock = vi.fn().mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          access_token: 'new-access-token',
-          refresh_token: 'new-refresh-token',
-          expires_at: Math.floor(Date.now() / 1000) + 7200,
-          athlete,
-        }),
-      ok: true,
-    });
-
-    vi.stubGlobal('fetch', fetchMock);
 
     const { result } = renderHook(() => useStravaAuth());
 
@@ -81,8 +66,8 @@ describe('useStravaAuth', () => {
       token = await result.current.refreshTokenIfNeeded();
     });
 
-    expect(token).toBe('new-access-token');
-    expect(sessionStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBe('new-access-token');
-    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(token).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN)).toBeNull();
   });
 });

--- a/packages/frontend/src/hooks/useStravaAuth.ts
+++ b/packages/frontend/src/hooks/useStravaAuth.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { AuthState, StravaAthlete } from '../types';
-import { STORAGE_KEYS, API_URL } from '../utils/constants';
+import { STORAGE_KEYS } from '../utils/constants';
 
 const initialState: AuthState = {
   accessToken: null,
@@ -29,7 +29,6 @@ interface UseStravaAuthReturn {
   refreshTokenIfNeeded: () => Promise<string | null>;
   setAuthFromCallback: (data: {
     access_token: string;
-    refresh_token: string;
     expires_at: number;
     athlete: StravaAthlete;
   }) => void;
@@ -43,15 +42,16 @@ export function useStravaAuth(): UseStravaAuthReturn {
   // Load auth from session storage on mount
   useEffect(() => {
     const accessToken = sessionStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
-    const refreshToken = sessionStorage.getItem(STORAGE_KEYS.REFRESH_TOKEN);
     const expiresAt = sessionStorage.getItem(STORAGE_KEYS.EXPIRES_AT);
     const athleteStr = sessionStorage.getItem(STORAGE_KEYS.ATHLETE);
 
-    if (accessToken && refreshToken && expiresAt) {
+    sessionStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
+
+    if (accessToken && expiresAt) {
       const athlete = parseStoredAthlete(athleteStr);
       setAuth({
         accessToken,
-        refreshToken,
+        refreshToken: null,
         expiresAt: parseInt(expiresAt, 10),
         athlete,
       });
@@ -82,67 +82,21 @@ export function useStravaAuth(): UseStravaAuthReturn {
       return auth.accessToken;
     }
 
-    if (!auth.refreshToken) {
-      return null;
-    }
-
-    try {
-      const response = await fetch(`${API_URL}/auth`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ refresh_token: auth.refreshToken }),
-      });
-
-      if (!response.ok) {
-        console.error('Failed to refresh token');
-        logout();
-        return null;
-      }
-
-      const data = (await response.json()) as {
-        access_token: string;
-        refresh_token: string;
-        expires_at: number;
-        athlete: StravaAthlete;
-      };
-
-      // Update storage
-      sessionStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, data.access_token);
-      sessionStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, data.refresh_token);
-      sessionStorage.setItem(STORAGE_KEYS.EXPIRES_AT, data.expires_at.toString());
-      sessionStorage.setItem(STORAGE_KEYS.ATHLETE, JSON.stringify(data.athlete));
-
-      setAuth({
-        accessToken: data.access_token,
-        refreshToken: data.refresh_token,
-        expiresAt: data.expires_at,
-        athlete: data.athlete,
-      });
-
-      return data.access_token;
-    } catch (error) {
-      console.error('Failed to refresh token:', error);
-      logout();
-      return null;
-    }
-  }, [auth.accessToken, auth.refreshToken, isTokenValid, logout]);
+    logout();
+    return null;
+  }, [auth.accessToken, isTokenValid, logout]);
 
   // Set auth after OAuth callback
   const setAuthFromCallback = useCallback(
-    (data: {
-      access_token: string;
-      refresh_token: string;
-      expires_at: number;
-      athlete: StravaAthlete;
-    }): void => {
+    (data: { access_token: string; expires_at: number; athlete: StravaAthlete }): void => {
       sessionStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, data.access_token);
-      sessionStorage.setItem(STORAGE_KEYS.REFRESH_TOKEN, data.refresh_token);
+      sessionStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
       sessionStorage.setItem(STORAGE_KEYS.EXPIRES_AT, data.expires_at.toString());
       sessionStorage.setItem(STORAGE_KEYS.ATHLETE, JSON.stringify(data.athlete));
 
       setAuth({
         accessToken: data.access_token,
-        refreshToken: data.refresh_token,
+        refreshToken: null,
         expiresAt: data.expires_at,
         athlete: data.athlete,
       });

--- a/packages/frontend/src/screens/StravaCallback/StravaCallback.tsx
+++ b/packages/frontend/src/screens/StravaCallback/StravaCallback.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useStravaAuth } from '@/hooks/useStravaAuth.ts';
-import { API_URL } from '@/utils/constants.ts';
+import { API_URL, STORAGE_KEYS } from '@/utils/constants.ts';
 import Loader from '../../components/Loader/Loader';
 import Footer from '../../components/Footer/Footer';
 import styles from './StravaCallback.module.css';
@@ -14,10 +14,19 @@ export default function StravaCallback(): React.JSX.Element {
 
   useEffect(() => {
     const code = searchParams.get('code');
+    const state = searchParams.get('state');
     const errorParam = searchParams.get('error');
+    const expectedState = sessionStorage.getItem(STORAGE_KEYS.OAUTH_STATE);
+
+    sessionStorage.removeItem(STORAGE_KEYS.OAUTH_STATE);
 
     if (errorParam) {
       setError('Authorization was denied. Please try again.');
+      return;
+    }
+
+    if (!state || !expectedState || state !== expectedState) {
+      setError('Invalid authorization state. Please try again.');
       return;
     }
 
@@ -31,7 +40,8 @@ export default function StravaCallback(): React.JSX.Element {
         const response = await fetch(`${API_URL}/auth`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ code }),
+          credentials: 'include',
+          body: JSON.stringify({ code, state }),
         });
 
         if (!response.ok) {

--- a/packages/frontend/src/utils/constants.ts
+++ b/packages/frontend/src/utils/constants.ts
@@ -25,4 +25,5 @@ export const STORAGE_KEYS = {
   REFRESH_TOKEN: 'strava_refresh_token',
   EXPIRES_AT: 'strava_expires_at',
   ATHLETE: 'strava_athlete',
+  OAUTH_STATE: 'strava_oauth_state',
 } as const;

--- a/packages/functions/lib/env.ts
+++ b/packages/functions/lib/env.ts
@@ -69,6 +69,7 @@ export function getCorsHeaders(origin?: string): Record<string, string> {
     'Access-Control-Allow-Origin': isAllowed ? origin : allowedOrigins[0] || '',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Credentials': 'true',
     'Content-Type': 'application/json',
   };
 }

--- a/packages/functions/src/auth.ts
+++ b/packages/functions/src/auth.ts
@@ -1,11 +1,14 @@
 import type { Context } from '@netlify/functions';
+import { randomBytes } from 'node:crypto';
 import type { StravaTokenResponse } from '../lib/types';
 import { STRAVA_TOKEN_URL } from '../lib/constants';
 import { getEnvConfig, getCorsHeaders } from '../lib/env';
 
+const OAUTH_STATE_COOKIE = 'strava_oauth_state';
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 const RATE_LIMIT_MAX = 20; // requests per window
 const RATE_LIMIT_WINDOW = 60_000; // 1 minute
+const OAUTH_STATE_MAX_AGE_SECONDS = 10 * 60;
 
 function isRateLimited(ip: string): boolean {
   const now = Date.now();
@@ -54,47 +57,53 @@ async function exchangeCodeForToken(
   return response.json() as Promise<StravaTokenResponse>;
 }
 
-/**
- * Refresh an expired access token
- */
-async function refreshAccessToken(
-  refreshToken: string,
-  clientId: string,
-  clientSecret: string,
-): Promise<StravaTokenResponse> {
-  const params = new URLSearchParams({
-    client_id: clientId,
-    client_secret: clientSecret,
-    refresh_token: refreshToken,
-    grant_type: 'refresh_token',
-  });
-
-  const response = await fetch(STRAVA_TOKEN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: params,
-  });
-
-  if (!response.ok) {
-    const error: FetchError = new Error(`Strava API error: ${response.status}`);
-    error.status = response.status;
-    throw error;
-  }
-
-  return response.json() as Promise<StravaTokenResponse>;
+interface AuthRequestBody {
+  action?: 'start';
+  code?: string;
+  state?: string;
 }
 
-interface AuthRequestBody {
-  code?: string;
-  refresh_token?: string;
+function parseCookies(cookieHeader: string | null): Map<string, string> {
+  const cookies = new Map<string, string>();
+  if (!cookieHeader) {
+    return cookies;
+  }
+
+  for (const cookie of cookieHeader.split(';')) {
+    const [name, ...valueParts] = cookie.trim().split('=');
+    if (!name || valueParts.length === 0) {
+      continue;
+    }
+    cookies.set(name, decodeURIComponent(valueParts.join('=')));
+  }
+
+  return cookies;
+}
+
+function buildStateCookie(state: string, req: Request): string {
+  const isSecure = new URL(req.url).protocol === 'https:';
+  const secureAttribute = isSecure ? '; Secure' : '';
+  return `${OAUTH_STATE_COOKIE}=${encodeURIComponent(
+    state,
+  )}; HttpOnly; Path=/; SameSite=Lax; Max-Age=${OAUTH_STATE_MAX_AGE_SECONDS}${secureAttribute}`;
+}
+
+function buildClearStateCookie(req: Request): string {
+  const isSecure = new URL(req.url).protocol === 'https:';
+  const secureAttribute = isSecure ? '; Secure' : '';
+  return `${OAUTH_STATE_COOKIE}=; HttpOnly; Path=/; SameSite=Lax; Max-Age=0${secureAttribute}`;
+}
+
+function generateOAuthState(): string {
+  return randomBytes(32).toString('hex');
 }
 
 /**
  * Netlify Function handler for Strava authentication
  *
  * Endpoints:
- * - POST /auth with { code: "xxx" } - Exchange OAuth code for tokens
- * - POST /auth with { refresh_token: "xxx" } - Refresh expired token
+ * - POST /auth with { action: "start" } - Issue OAuth state
+ * - POST /auth with { code: "xxx", state: "xxx" } - Exchange OAuth code for access token
  */
 export default async (req: Request, context: Context): Promise<Response> => {
   const origin = req.headers.get('origin') ?? undefined;
@@ -103,6 +112,13 @@ export default async (req: Request, context: Context): Promise<Response> => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 200, headers });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers,
+    });
   }
 
   // Rate limiting
@@ -118,64 +134,58 @@ export default async (req: Request, context: Context): Promise<Response> => {
     // Validate environment
     const config = getEnvConfig();
 
-    // Parse body for code or refresh_token
-    let code: string | undefined;
-    let refreshToken: string | undefined;
+    // Parse body for OAuth state or code exchange
+    let body: AuthRequestBody;
 
-    if (req.method === 'POST') {
-      try {
-        const body = (await req.json()) as AuthRequestBody;
-        code = body.code;
-        refreshToken = body.refresh_token;
-      } catch {
-        // Body parsing failed, check query params as fallback for code (OAuth callback)
-      }
-    }
-
-    // Fallback to query params for OAuth code (redirect from Strava)
-    if (!code && !refreshToken) {
-      const { searchParams } = context.url;
-      code = searchParams.get('code') ?? undefined;
-    }
-
-    if (!code && !refreshToken) {
-      return new Response(JSON.stringify({ error: 'Missing code or refresh_token' }), {
+    try {
+      body = (await req.json()) as AuthRequestBody;
+    } catch {
+      return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
         status: 400,
         headers,
       });
     }
 
-    let tokenResponse: StravaTokenResponse;
+    if (body.action === 'start') {
+      const state = generateOAuthState();
+      return new Response(JSON.stringify({ state }), {
+        status: 200,
+        headers: { ...headers, 'Set-Cookie': buildStateCookie(state, req) },
+      });
+    }
 
-    if (code) {
-      tokenResponse = await exchangeCodeForToken(
-        code,
-        config.STRAVA_CLIENT_ID,
-        config.STRAVA_CLIENT_SECRET,
-      );
-    } else if (refreshToken) {
-      tokenResponse = await refreshAccessToken(
-        refreshToken,
-        config.STRAVA_CLIENT_ID,
-        config.STRAVA_CLIENT_SECRET,
-      );
-    } else {
-      return new Response(JSON.stringify({ error: 'Invalid request' }), {
+    const { code, state } = body;
+
+    if (!code) {
+      return new Response(JSON.stringify({ error: 'Missing code' }), {
         status: 400,
         headers,
       });
     }
+
+    const expectedState = parseCookies(req.headers.get('cookie')).get(OAUTH_STATE_COOKIE);
+    if (!state || !expectedState || state !== expectedState) {
+      return new Response(JSON.stringify({ error: 'Invalid state' }), {
+        status: 400,
+        headers: { ...headers, 'Set-Cookie': buildClearStateCookie(req) },
+      });
+    }
+
+    const tokenResponse = await exchangeCodeForToken(
+      code,
+      config.STRAVA_CLIENT_ID,
+      config.STRAVA_CLIENT_SECRET,
+    );
 
     return new Response(
       JSON.stringify({
         access_token: tokenResponse.access_token,
-        refresh_token: tokenResponse.refresh_token,
         expires_at: tokenResponse.expires_at,
         athlete: tokenResponse.athlete,
       }),
       {
         status: 200,
-        headers,
+        headers: { ...headers, 'Set-Cookie': buildClearStateCookie(req) },
       },
     );
   } catch (error: unknown) {

--- a/packages/functions/src/sign.ts
+++ b/packages/functions/src/sign.ts
@@ -15,6 +15,7 @@ import { getCorsHeaders, getEnvConfig } from '../lib/env';
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 const RATE_LIMIT_MAX = 10;
 const RATE_LIMIT_WINDOW = 60_000;
+const SIGNATURE_TTL_SECONDS = 10 * 60;
 
 function isRateLimited(ip: string): boolean {
   const now = Date.now();
@@ -58,7 +59,9 @@ async function getActivitySegments(
 async function signSegment(
   walletClient: WalletClient,
   segmentId: number,
+  completionDate: number,
   subject: Address,
+  deadline: number,
   chainId: number,
 ): Promise<Hex> {
   const isMainnet = chainId === linea.id;
@@ -74,7 +77,9 @@ async function signSegment(
   const types = {
     Segment: [
       { name: 'segmentId', type: 'uint256' },
+      { name: 'completionDate', type: 'uint64' },
       { name: 'subject', type: 'address' },
+      { name: 'deadline', type: 'uint64' },
     ],
   } as const;
 
@@ -85,7 +90,9 @@ async function signSegment(
 
   const message = {
     segmentId: BigInt(segmentId),
+    completionDate: BigInt(completionDate),
     subject,
+    deadline: BigInt(deadline),
   };
 
   return await walletClient.signTypedData({
@@ -175,6 +182,8 @@ export default async (req: Request, context: Context): Promise<Response> => {
 
     const isMainnet = chainId === linea.id;
     const chain = isMainnet ? linea : lineaSepolia;
+    const completionDate = Math.floor(new Date(segmentEffort.start_date).getTime() / 1000);
+    const deadline = Math.floor(Date.now() / 1000) + SIGNATURE_TTL_SECONDS;
 
     const walletClient = createWalletClient({
       account: privateKeyToAccount(config.SIGNER_PRIVATE_KEY),
@@ -182,11 +191,19 @@ export default async (req: Request, context: Context): Promise<Response> => {
       transport: http(),
     });
 
-    const signature = await signSegment(walletClient, segmentId, subject as Address, chainId);
+    const signature = await signSegment(
+      walletClient,
+      segmentId,
+      completionDate,
+      subject as Address,
+      deadline,
+      chainId,
+    );
 
     const signedSegment: SignedSegment = {
       segmentId: segmentEffort.segment.id,
-      completionDate: Math.floor(new Date(segmentEffort.start_date).getTime() / 1000),
+      completionDate,
+      deadline,
       signature,
     };
 

--- a/packages/functions/test/auth.test.ts
+++ b/packages/functions/test/auth.test.ts
@@ -1,0 +1,126 @@
+import type { Context } from '@netlify/functions';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import authHandler from '../src/auth';
+
+vi.mock('../lib/constants', () => ({
+  STRAVA_TOKEN_URL: 'https://www.strava.com/oauth/token',
+}));
+
+function createContext(ip = '203.0.113.10'): Context {
+  return { ip } as Context;
+}
+
+function createAuthRequest(body: unknown, cookie?: string): Request {
+  return new Request('https://functions.example.com/auth', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      origin: 'https://app.example.com',
+      ...(cookie ? { cookie } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('auth handler', () => {
+  beforeEach(() => {
+    vi.stubEnv('STRAVA_CLIENT_ID', 'client-id');
+    vi.stubEnv('STRAVA_CLIENT_SECRET', 'client-secret');
+    vi.stubEnv('FRONTEND_URL', 'https://app.example.com');
+    vi.stubEnv('SIGNER_PRIVATE_KEY', `0x${'1'.repeat(64)}`);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('rejects legacy refresh token requests without calling Strava', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await authHandler(
+      createAuthRequest({ refresh_token: 'stolen-token' }),
+      createContext('203.0.113.11'),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: 'Missing code' });
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('issues an HttpOnly OAuth state cookie', async () => {
+    const response = await authHandler(
+      createAuthRequest({ action: 'start' }),
+      createContext('203.0.113.14'),
+    );
+    const body = (await response.json()) as { state?: string };
+    const cookie = response.headers.get('set-cookie');
+
+    expect(response.status).toBe(200);
+    expect(body.state).toMatch(/^[a-f0-9]{64}$/);
+    expect(cookie).toContain(`strava_oauth_state=${body.state}`);
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Lax');
+  });
+
+  it('rejects code exchange when OAuth state does not match the cookie', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await authHandler(
+      createAuthRequest({ code: 'oauth-code', state: 'wrong-state' }, 'strava_oauth_state=state'),
+      createContext('203.0.113.15'),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid state' });
+    expect(response.status).toBe(400);
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not expose Strava refresh tokens to the browser', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: 'access-token',
+          refresh_token: 'strava-refresh-token',
+          expires_at: 1893456000,
+          athlete: { id: 123, username: 'athlete' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await authHandler(
+      createAuthRequest({ code: 'oauth-code', state: 'state' }, 'strava_oauth_state=state'),
+      createContext('203.0.113.12'),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      access_token: 'access-token',
+      expires_at: 1893456000,
+      athlete: { id: 123, username: 'athlete' },
+    });
+    expect(body.refresh_token).toBeUndefined();
+    expect(response.headers.get('set-cookie')).toContain('Max-Age=0');
+  });
+
+  it('rejects non-POST requests', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await authHandler(
+      new Request('https://functions.example.com/auth?code=oauth-code', { method: 'GET' }),
+      createContext('203.0.113.13'),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: 'Method not allowed' });
+    expect(response.status).toBe(405);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/functions/test/env.test.ts
+++ b/packages/functions/test/env.test.ts
@@ -13,6 +13,7 @@ describe('CORS Headers Logic', () => {
       'Access-Control-Allow-Origin': isAllowed ? origin : allowedOrigins[0] || '',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Allow-Credentials': 'true',
       'Content-Type': 'application/json',
     };
   }
@@ -53,6 +54,7 @@ describe('CORS Headers Logic', () => {
 
     expect(headers['Access-Control-Allow-Methods']).toBe('GET, POST, OPTIONS');
     expect(headers['Access-Control-Allow-Headers']).toBe('Content-Type, Authorization');
+    expect(headers['Access-Control-Allow-Credentials']).toBe('true');
     expect(headers['Content-Type']).toBe('application/json');
   });
 });
@@ -111,6 +113,13 @@ describe('Rate Limiting Logic', () => {
 });
 
 describe('Input Validation', () => {
+  it('should reject legacy refresh token auth requests', () => {
+    const body = { refresh_token: 'stolen-token' };
+    const hasSupportedGrant = 'code' in body;
+
+    expect(hasSupportedGrant).toBe(false);
+  });
+
   it('should validate Ethereum address format', () => {
     const addressRegex = /^0x[a-fA-F0-9]{40}$/;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -64,6 +64,7 @@ export interface Activity {
 
 export interface AuthState {
   accessToken: string | null;
+  /** @deprecated refresh tokens are not stored in the browser. */
   refreshToken: string | null;
   expiresAt: number | null;
   athlete: StravaAthlete | null;
@@ -72,6 +73,7 @@ export interface AuthState {
 export interface SignedSegment {
   segmentId: number;
   completionDate: number;
+  deadline: number;
   signature: Hex;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,7 @@ overrides:
   '@netlify/edge-bundler>uuid': 11.1.1
   netlify-cli>uuid: 13.0.1
   '@netlify/dev-utils>uuid': 13.0.1
+  fast-uri: 3.1.2
 
 importers:
 
@@ -4303,11 +4304,8 @@ packages:
   fast-stringify@4.0.0:
     resolution: {integrity: sha512-lE2DIivBaLysf6hK5WH/VfMgqRbvBVHcpGVVTmA5Zi8oWIjq9YxIt6lYGdUgP1HNSXxTIat7HEIDnrSvXSeKQw==}
 
-  fast-uri@2.4.0:
-    resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
-
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -8036,7 +8034,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
 
   '@fastify/busboy@3.2.0': {}
 
@@ -11464,7 +11462,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12616,7 +12614,7 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-deep-equal: 3.1.3
-      fast-uri: 2.4.0
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 1.0.1
       rfdc: 1.4.1
 
@@ -12625,7 +12623,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -12642,9 +12640,7 @@ snapshots:
 
   fast-stringify@4.0.0: {}
 
-  fast-uri@2.4.0: {}
-
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,3 +69,5 @@ overrides:
   # GHSA-w5hq-g745-h8pq: Netlify CLI and dev-utils accept the patched uuid 13.x release.
   'netlify-cli>uuid': 13.0.1
   '@netlify/dev-utils>uuid': 13.0.1
+  # GHSA-q3j6-qgpj-74h6: force Verax GraphQL transitive paths onto the patched URI parser.
+  fast-uri: 3.1.2


### PR DESCRIPTION
## Summary
- Bind Strava attestation signatures to `completionDate` and a short-lived `deadline`
- Reject replayed attestations onchain and align portal admin permissions with the Verax portal owner
- Harden OAuth state handling with a backend-issued HttpOnly state cookie and stop browser refresh-token exchange
- Override vulnerable transitive `uuid@13.0.0` to a patched release

## Validation
- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `pnpm format`
- `pnpm audit --prod --json`