### PR TITLE
fix(netlify): prevent SPA redirect loops

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -27,24 +27,22 @@
   status = 200
 
 [[redirects]]
-  from = "/about/"
-  to = "/about"
-  status = 301
-  force = true
-
-[[redirects]]
-  from = "/oauth/"
-  to = "/oauth"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "/about"
   to = "/index.html"
   status = 200
 
 [[redirects]]
+  from = "/about/"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
   from = "/oauth"
+  to = "/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/oauth/"
   to = "/index.html"
   status = 200
 


### PR DESCRIPTION
## Summary
- route both canonical and trailing-slash SPA paths directly to index.html
- avoid Netlify self-redirect loops on /about and /oauth

## Validation
- pnpm lint
- production smoke test passed after manual deploy with equivalent redirects